### PR TITLE
chore: first review

### DIFF
--- a/sim-card-auth-ios/README.md
+++ b/sim-card-auth-ios/README.md
@@ -1,13 +1,19 @@
 # SIM Card Based Mobile Authentication [with tru.ID]
 
 ## Overview
-The tru.ID SubscriberCheck provides a solution that offers both phone number verification and SIM checking. SIM Check Service provides information on when a SIM card associated with a mobile phone number was last changed. This can be used when augmenting existing 2FA or anti-fraud workflows.
+**tru.ID** SubscriberCheck is a solution that offers both mobile phone number verification and SIM swap detection. SIM Check Service provides information on when a SIM card associated with a mobile phone number was last changed. This can be used when augmenting existing 2FA or anti-fraud workflows.
 
 PhoneCheck on the other hand provides.
 
 SubscriberCheck simplifies and combines the functionality offered by both PhoneCheck and SIMCheck into a single product.
 
+**TODO: ☝️ Good idea to have an intro to talk about SubscriberCheck. We should focus on just that product because, although it is built upon the other products, I feel it complicates things. What is SubscriberCheck, how does it work and why should you care.**
+
 ## How to run this project?
+
+**TODO: ☝️ The tutorial should focus on building the project. The "how to run" instructions should go in README of the associated repo**
+
+**TODO: 👇 Having these instructions makes sense. I'd just not frame them as prep for running the project. More foundational steps so you can begin development**
 
 ### Step 1 - Have your fundamentals
 You will need to follow a few steps before you can run this sample app. If you have not done so;
@@ -19,11 +25,11 @@ You will need to follow a few steps before you can run this sample app. If you h
 Xcode and this sample project will take care of generating necessariy certificates and provisioning profiles in order to install the app on the device.
 
 ### Step 2 - Set-up tru.ID CLI and run a development server
-For us to run the Subcriber Check workflow, you will also need to install [**tru.ID** CLI](https://github.com/tru-ID/cli)  and run a Node.js development server.
+For us to run the SubcriberCheck workflow, you will also need to install [**tru.ID** CLI](https://github.com/tru-ID/cli) and run a Node.js development server.
 
 The CLI helps you create a local development server on your machine. It opens up a local tunnel to this server and making it publicly accessible over the Internet. This will allow your mobile phone to access this server when connected only through cellular data. 
 
-First sign up for a [**tru.ID** account](https://developer.tru.id/signup) account, and do not forget to note down your Client Id, Client Secret and Data Residency information. The account comes with some free credits, so you can use it for testing your app against the production environment when it is ready.
+First sign up for a [**tru.ID** account](https://developer.tru.id/signup) account. The account comes with some free credits, so you can use it for testing your app against the production environment when it is ready.
 
 Download and install [**Node.js**](https://nodejs.org/en/download/) if you do not have it already. After installing Node.js, use the following terminal command to install [**tru.ID** CLI](https://github.com/tru-ID/cli):
 
@@ -31,7 +37,7 @@ Download and install [**Node.js**](https://nodejs.org/en/download/) if you do no
 $ npm install -g @tru_id/cli
 ```
 
-Run `tru setup:credentials` command using the credentials you have noted before from the [**tru.ID** console](https://developer.tru.id/console):
+Run `tru setup:credentials` command using the command you can copy from the [**tru.ID** console](https://developer.tru.id/console):
 
 ```bash
 $ tru setup:credentials {client_id} {client_secret} {data_residency}
@@ -59,6 +65,8 @@ $ tru server -t --project-dir ./iosauthdemoserver
 
 Check URL that is shown in the terminal using your web browser and see if you it is accessible. The URL will be in the format `https://{subdomain}.loca.lt`.
 
+**TODO: 👇 As per the other comments, I'd suggest removing this running part. At this point there would be nothing to run because the developer hasn't written any code**
+
 ### Step 3 - Configure the project and run
 The development server is now ready waiting to accept the calls from the app you will be running through Xcode. Now, we need add the url you see on the console to a configuration file in the project.
 
@@ -85,14 +93,18 @@ Observer on the terminal that the calls from the application hits the developmen
 
 ## Getting **tru.ID** integrated with your iOS application
 
+**TODO: 👇 If feels like this next section is a duplication of some of the above**
+
 ### Before you Begin
-If you have come this far, you already have Xcode, a tru.ID account and the necessary CLI and development server set-up and running. For you to integrate tru.ID with your own applications, you will need:
+If you have come this far, you already have Xcode, a **tru.ID** account and the necessary CLI and development server set-up and running. For you to integrate **tru.ID** with your own applications, you will need:
 
 - Knowledge of Swift language
 - Experience with iOS application development 
 - Xcode
 
-If so, let's dive straight into adding Subscriber Check functionality to your iOS applications.
+If so, let's dive straight into adding SubscriberCheck functionality to your iOS applications.
+
+**TODO: 👇 This is where the real tutorial content begins: creating a project, creating classes/functions/adding files/views etc.**
 
 ### Create an iOS Project
 If you already have an iOS project, you can skip this step. Otherwise;
@@ -101,19 +113,23 @@ If you already have an iOS project, you can skip this step. Otherwise;
 
 ```
 
-### Add tru.Id iOS SDK
-Let's add the tru.Id iOS SDK first. This will SDK ensures that certain network calls are done on celluar network type, which is need to run Subcriber Check workflow.
+### Add **tru.ID** iOS SDK
+Let's add the **tru.ID** iOS SDK first. This SDK ensures that certain network calls are done on celluar network type, which is needed to run the SubcriberCheck workflow.
 
 Go to File -> Swift Packages -> Add Package Dependency...
 
 Type `git@github.com:tru-ID/tru-sdk-ios.git`, and tap Next.
 
+**TODO: ☝️ We have publish to Cocoapods. Is adding from Git better/easier?**
+
 Xcode should be able to find the package. Check the correct version is selected.
 
 Now that the SDK is added, we can import it when we are implementing the workflow.
 
-### Add tru.Id endpoints
-You app may have its own ways to defining and access external service URLs, and these endpoints may be stored in configuration files such as a plist, or in your swift code. In this tutorial, we will be storing the development and production base URLs for the endpoints in a plist called TruIdService-Info.plist.
+**TODO: 👇 These are really server endpoints that proxy requests through to the tru.ID API. Should probably talk about it this way**
+
+### Add **tru.ID** endpoints
+Your app may have its own ways to defining and accessing external service URLs, and these endpoints may be stored in configuration files such as a plist, or in your swift code. In this tutorial, we will be storing the development and production base URLs for the endpoints in a plist called TruIdService-Info.plist.
 
 We will add two keys one for the development endpoints and one for the production endpoints.
 


### PR DESCRIPTION
Provided some suggestions and pointers. In general, it currently feels like a merge of a README and a tutorial. Let's have the repo README walk the developer on getting the completed app to run. The tutorial should walk the developer through building the app from scratch (though we can provide a starter template if that makes sense).

Repo structure:

Not sure we need the sub-directory so I'd push everything up one level unless that follows an iOS application Git repo convention. So, one README (as above), the code assets and a `tutorial.md` (or similar) that we'll remove once completed and put on `developer.tru.id/tutorials/{slug}` (once we have the `/tutorials` section live).